### PR TITLE
Remove unused variable

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -582,7 +582,6 @@
    * @param {{fatal: boolean}} options
    */
   function UTF8Encoder(options) {
-    var fatal = options.fatal;
     /**
      * @param {Stream} stream Input stream.
      * @param {number} code_point Next code point read from the stream.


### PR DESCRIPTION
The variable `fatal` is never used in `TextEncoder`, so remove it.